### PR TITLE
CD: Change to fit function for vertex comapre

### DIFF
--- a/Silicon_MBD_Vertexing/vertexCompare.C
+++ b/Silicon_MBD_Vertexing/vertexCompare.C
@@ -1,4 +1,5 @@
 #include <TMath.h>
+#include <TF1.h>
 #include "sPhenixStyle.C"
 
 SetsPhenixStyle();
@@ -27,7 +28,8 @@ void savePlots(T myPlot, string typeCompare, float fitMin = -1.5, float fitMax =
 
   float labelPosition[4];
 
-  string gauss = "[0]*Gaus(x, [1], [2])";
+  string gauss = "gaus";
+  //string gauss = "[0]*Gaus(x, [1], [2])";
   TF1* fitFunc = new TF1 ("f", gauss.c_str(), fitMin, fitMax);
   fitFunc->SetLineColor(kRed);
   fitFunc->SetParName(0, "Const"); fitFunc->SetParameter(0, 10); fitFunc->SetParLimits(0, 0, 10000);


### PR DESCRIPTION
@jdosbo can we merge this and pull it to our area that makes the silicon/MBD plots to see if this fixes the plotting issue Ron mentioned in the SCM? I can check the output tonight on owl and if it doesnt work then I'll just change it to get the mean and width of the historgram, removing the fit altogether