### PR TITLE
fixed paths in include

### DIFF
--- a/SiliconQA/macros/run_SiliconQA.C
+++ b/SiliconQA/macros/run_SiliconQA.C
@@ -1,7 +1,6 @@
-#include </sphenix/user/kgable/TrackingAnalysis/SiliconQA/SiliconQA.h>
+#include <SiliconQA.h>
 
-//R__LOAD_LIBRARY(libSiliconQA.so)
-R__LOAD_LIBRARY(/sphenix/user/kgable/TrackingAnalysis/SiliconQA/build/.libs/libSiliconQA.so)
+R__LOAD_LIBRARY(libSiliconQA.so)
 
 void run_SiliconQA()
 {


### PR DESCRIPTION
Changed the path of the includes because they pointed to the specific location of my own personal versions of the file.